### PR TITLE
refactor(all): remove redundant inventory variables for containerized…

### DIFF
--- a/collections/ansible_collections/demo/aap_utilities/roles/aap_setup_install/tasks/main.yml
+++ b/collections/ansible_collections/demo/aap_utilities/roles/aap_setup_install/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Debug testing
-  ansible.builtin.debug:
-    var: aap_setup_prep_setup_dir
-
 - name: Ensure the inventory file is prepared for installation
   ansible.builtin.template:
     src: inventory.j2

--- a/inventory/group_vars/all/install.yml
+++ b/inventory/group_vars/all/install.yml
@@ -5,37 +5,4 @@ aap_setup_down_version: 2.4
 aap_setup_rhel_version: "{{ ansible_distribution_major_version }}"
 
 aap_setup_prep_process_template: false
-aap_setup_inst_containerized: true
 aap_setup_containerized: true
-
-aap_setup_prep_inv_nodes:
-  automationcontroller: "{{ groups['automationcontroller'] }}"
-  automationeda: "{{ groups['automationcontroller'] }}"
-  automationhub: "{{ groups['automationcontroller'] }}"
-  database: "{{ groups['automationcontroller'] }}"
-
-aap_setup_prep_inv_vars:
-  all:
-    ansible_connection: local
-    admin_password: "{{ admin_password }}"
-
-    registry_username: "{{ redhat_username }}"
-    registry_password: "{{ redhat_password }}"
-
-    # Automation Controller
-    controller_admin_password: "{{ admin_password }}"
-    controller_pg_host: "{{ groups['automationcontroller'][0] }}"
-
-    # Automation Hub
-    hub_admin_password: "{{ admin_password }}"
-    hub_pg_host: "{{ groups['automationcontroller'][0] }}"
-    hub_pg_password: "{{ admin_password }}"
-
-    # Automation EDA Controller
-    eda_admin_password: "{{ admin_password }}"
-    eda_pg_host: "{{ groups['automationcontroller'][0] }}"
-    eda_pg_password: "{{ admin_password }}"
-
-    # Postgres
-    postgresql_admin_username: postgres
-    postgresql_admin_password: "{{ admin_password }}"


### PR DESCRIPTION
… setup

Removed unnecessary inventory variables related to the containerized setup of automation platform components. Simplified the inventory by consolidating the `aap_setup_inst_containerized` and `aap_setup_containerized` flags and removing specific inventory node groups and variables that are no longer required. This change aims to streamline the configuration process and reduce complexity.