### PR TITLE
feat: add controller secret key and ensure token creation

### DIFF
--- a/collections/ansible_collections/demo/aap_utilities/roles/aap_setup_install/templates/inventory.j2
+++ b/collections/ansible_collections/demo/aap_utilities/roles/aap_setup_install/templates/inventory.j2
@@ -23,6 +23,7 @@ bundle_dir='{{ aap_setup_prep_setup_dir }}/bundle'
 # Automation Controller
 controller_admin_user='{{ admin_username }}'
 controller_admin_password='{{ admin_password }}'
+controller_secret_key='{{ automation_controller_secret }}
 controller_pg_host='{{ inventory_hostname }}'
 controller_pg_password='{{ admin_password }}'
 controller_license_file='{{ aap_setup_prep_setup_dir }}/manifest.zip'

--- a/collections/ansible_collections/demo/aap_utilities/roles/aap_setup_postinstall/tasks/main.yml
+++ b/collections/ansible_collections/demo/aap_utilities/roles/aap_setup_postinstall/tasks/main.yml
@@ -24,3 +24,23 @@
         created = EXCLUDED.created
     positional_args:
       - "{{ automation_hub_token }}"
+
+- name: Ensure the Automation Controller token is created
+  community.postgresql.postgresql_query:
+    db: "awx"
+    login_host: "localhost"
+    login_user: "postgres"
+    login_password: "{{ admin_password }}"
+    query: >-
+      INSERT INTO main_oauth2accesstoken (user_id, description, token, scope, expires, modified, created, updated)
+      VALUES (1, 'Event Driven Ansible', %s, 'write', NOW() + interval '1000 years', NOW(), NOW(), NOW())
+      ON CONFLICT (token)
+      DO UPDATE SET
+        user_id = EXCLUDED.user_id,
+        description = EXCLUDED.description,
+        scope = EXCLUDED.scope,
+        expires = EXCLUDED.expires,
+        modified = EXCLUDED.modified,
+        updated = EXCLUDED.updated
+    positional_args:
+      - "{{ automation_controller_token }}"

--- a/vaults/demo.secret.yml
+++ b/vaults/demo.secret.yml
@@ -3,6 +3,8 @@ redhat_username: ENC[AES256_GCM,data:koTwP1isYsjTByABYiQ=,iv:gB2j8S7SpefTaxgWrjc
 redhat_password: ENC[AES256_GCM,data:iNwyzmSM4ETxEpCYtEhYbHCu2Uc=,iv:pmUP83X2HR5ODaUqqBJ6cWgqasx0wquBct/BJCF2wow=,tag:UtlXcLRXIdEbsPOq8f1N1Q==,type:str]
 admin_username: ENC[AES256_GCM,data:wmvPIwCtWA==,iv:HuF0v9sALVhq4xCWRSaKci7Vfcg0HlYFDb/U5jGF7A8=,tag:eCKpxt0/EryNJbKeMDUTfw==,type:str]
 admin_password: ENC[AES256_GCM,data:DbmNdV06REG8PWySno6OLs0XSCBQZS5gcqHZ3ct+jmgralfC,iv:8OcaEOmDKKGF/FBnbvgH0pJV1TfDw6N7dxkql9IggJ0=,tag:2Qcqu375t4ucnS0tk6p+Ew==,type:str]
+automation_controller_token: ENC[AES256_GCM,data:15VDCU4Pae2f0wUrk6GCjPBKGT4fEcECPDLqVRkT,iv:ZAxPkJNPUf+CdKANlh+sasFNG+NVkv2AUymL9YOiTcc=,tag:YfSIgHcb8vnZfvfxfuCF4g==,type:str]
+automation_controller_secret: ENC[AES256_GCM,data:7eW7SFUESuOYu899b7qoSj+Ueh7kcaZ6zanmF+YvSfvb/MjNWG/peLJ77Fvrf5ko6Ko=,iv:26XWbAByEByOGMvHfgXw1YD/ywcCq3ftXVAQCTjmbbQ=,tag:d4Oxo0wggPBvygRUdyWWjQ==,type:str]
 automation_hub_token: ENC[AES256_GCM,data:rdzlIYg0wgn+xx6zLh3nIu0GfKezItfskaZsx7FQ1uSsuMycdZtYMw==,iv:5lfToAgIdtjX9V7Z50hp5jBJInOu1Kdv5yGb3vWuyHg=,tag:mhxHA4s7p0cegEd3scFFqg==,type:str]
 sops:
     kms: []
@@ -19,8 +21,8 @@ sops:
             R2tSNCs3UFNYaEpLTUpmOHJhM21LTjQK0R9zVPvC9pcTYryTKsJMDSaUbauzUAJ8
             gCLI2HT5uoc5w/E53ULB0g/RE/8JbguXUOoL4JPvkzXsfcaaEaSD6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-17T17:21:15Z"
-    mac: ENC[AES256_GCM,data:N+mOjRVIRiKLLPdWZkeIr1QTx4tFFW9TbKjJScLJ1XI30mkX7gp6VyYirnLaFUaVEoKXeX1U8jU/xQJmtOnbwFuha/yVYQX84PBcKESigu3773vfiXd+jhdE4QiFnDk2HgXVGPkXJNmYo4Y1Ito/c4gquBmdaSckv8+mJ7pvPTM=,iv:H093iuW34qS7l8g6l7VBVVRBtPNpHP5JMToyNzjB37c=,tag:zLVFYl/4XhP6hNmy63jWTA==,type:str]
+    lastmodified: "2024-06-17T19:02:40Z"
+    mac: ENC[AES256_GCM,data:PHVyUydLvLMD8h9S2CkB8AAqqHOqjbOQcaMfIlUt9y4W66WKeGNavZQNWq+yAY+6k4aGrYLowoEjyGm9pCU2QO2SgT0uQvgTjY59nJ2NNcHPAYwTdo69kUZCQWet++zR3N5fY/QJI6EfZ728OlPSnFcvH2e+V+cIx9vbMWIuvqc=,iv:RqhtIVZ4zKl3zTHmDXmV26Yd7UEveUhwHVpweVfhNQE=,tag:i/FOVz3hzCOH4Vumd8QglQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1


### PR DESCRIPTION
- Add `controller_secret_key` variable to the inventory template for Automation Controller.
- Ensure the Automation Controller token is created with a new task in the post-install playbook.
- Update encrypted values for `automation_controller_token` and `automation_controller_secret` in the vault file.